### PR TITLE
Adding check for text headers in csv/tsv files

### DIFF
--- a/rival-core/src/main/java/net/recommenders/rival/core/SimpleParser.java
+++ b/rival-core/src/main/java/net/recommenders/rival/core/SimpleParser.java
@@ -41,7 +41,10 @@ public class SimpleParser implements Parser {
         DataModel<Long, Long> dataset = new DataModel<Long, Long>();
 
         BufferedReader br = new BufferedReader(new FileReader(f));
-        String line = null;
+        String line = br.readLine();
+        if (!line.matches(".*[a-zA-Z].*")) {
+            parseLine(line, dataset, token);
+        }
         while ((line = br.readLine()) != null) {
             parseLine(line, dataset, token);
         }


### PR DESCRIPTION
This is a quick fix for using csv/tsv files with string headers. The code checks wheather the first line in the file contains [a-zAZ], if so it skips the line, otherwise parses it like all other lines.

This should probably be fixed with a Java Pattern, or perhaps we could use a CSV library instead, e.g. Apache Commons CSV (https://commons.apache.org/proper/commons-csv/).
