### PR TITLE
Generalized DataModel for error and ranking evaluation metrics

### DIFF
--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/AbstractMetric.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/AbstractMetric.java
@@ -5,6 +5,8 @@ import net.recommenders.rival.core.DataModel;
 import java.util.*;
 
 /**
+ * @param <U> - type associated to users' ids
+ * @param <I> - type associated to items' ids
  * @author <a href="http://github.com/alansaid">Alan</a>.
  */
 public abstract class AbstractMetric<U, I> implements EvaluationMetric<U> {

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/AbstractMetric.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/AbstractMetric.java
@@ -1,25 +1,26 @@
 package net.recommenders.rival.evaluation.metric;
 
-import java.util.*;
 import net.recommenders.rival.core.DataModel;
+
+import java.util.*;
 
 /**
  * @author <a href="http://github.com/alansaid">Alan</a>.
  */
-public abstract class AbstractMetric implements EvaluationMetric<Long> {
+public abstract class AbstractMetric<U, I> implements EvaluationMetric<U> {
 
     /**
      * The predictions.
      */
-    protected DataModel<Long, Long> predictions;
+    protected DataModel<U, I> predictions;
     /**
      * The test set.
      */
-    protected DataModel<Long, Long> test;
+    protected DataModel<U, I> test;
     /**
      * Metric per user
      */
-    protected Map<Long, Double> metricPerUser;
+    protected Map<U, Double> metricPerUser;
 
     /**
      * Default constructor with predictions and groundtruth information
@@ -27,18 +28,18 @@ public abstract class AbstractMetric implements EvaluationMetric<Long> {
      * @param predictions predicted scores for users and items
      * @param test groundtruth information for users and items
      */
-    public AbstractMetric(DataModel<Long, Long> predictions, DataModel<Long, Long> test) {
+    public AbstractMetric(DataModel<U, I> predictions, DataModel<U, I> test) {
         this.predictions = predictions;
         this.test = test;
 
-        this.metricPerUser = new HashMap<Long, Double>();
+        this.metricPerUser = new HashMap<U, Double>();
     }
 
     /**
      * @inheritDoc
      */
     @Override
-    public Map<Long, Double> getValuePerUser() {
+    public Map<U, Double> getValuePerUser() {
         return metricPerUser;
     }
 
@@ -46,7 +47,7 @@ public abstract class AbstractMetric implements EvaluationMetric<Long> {
      * @inheritDoc
      */
     @Override
-    public double getValue(Long u) {
+    public double getValue(U u) {
         if (metricPerUser.containsKey(u)) {
             return metricPerUser.get(u);
         }
@@ -59,22 +60,22 @@ public abstract class AbstractMetric implements EvaluationMetric<Long> {
      * @param userItems map with scores for each item
      * @return the ranked list
      */
-    protected List<Long> rankItems(Map<Long, Double> userItems) {
-        List<Long> sortedItems = new ArrayList<Long>();
+    protected List<I> rankItems(Map<I, Double> userItems) {
+        List<I> sortedItems = new ArrayList<I>();
         if (userItems == null) {
             return sortedItems;
         }
-        Map<Double, Set<Long>> itemsByRank = new HashMap<Double, Set<Long>>();
-        for (Map.Entry<Long, Double> e : userItems.entrySet()) {
-            long item = e.getKey();
+        Map<Double, Set<I>> itemsByRank = new HashMap<Double, Set<I>>();
+        for (Map.Entry<I, Double> e : userItems.entrySet()) {
+            I item = e.getKey();
             double pref = e.getValue();
             if (Double.isNaN(pref)) {
                 // we ignore any preference assigned as NaN
                 continue;
             }
-            Set<Long> items = itemsByRank.get(pref);
+            Set<I> items = itemsByRank.get(pref);
             if (items == null) {
-                items = new HashSet<Long>();
+                items = new HashSet<I>();
                 itemsByRank.put(pref, items);
             }
             items.add(item);
@@ -82,10 +83,10 @@ public abstract class AbstractMetric implements EvaluationMetric<Long> {
         List<Double> sortedScores = new ArrayList<Double>(itemsByRank.keySet());
         Collections.sort(sortedScores, Collections.reverseOrder());
         for (double pref : sortedScores) {
-            List<Long> sortedPrefItems = new ArrayList<Long>(itemsByRank.get(pref));
+            List<I> sortedPrefItems = new ArrayList<I>(itemsByRank.get(pref));
             // deterministic output when ties in preferences: sort by item id
             Collections.sort(sortedPrefItems, Collections.reverseOrder());
-            for (long itemID : sortedPrefItems) {
+            for (I itemID : sortedPrefItems) {
                 sortedItems.add(itemID);
             }
         }
@@ -98,12 +99,12 @@ public abstract class AbstractMetric implements EvaluationMetric<Long> {
      * @param userItems map with scores for each item
      * @return the ranked list
      */
-    protected List<Double> rankScores(Map<Long, Double> userItems) {
+    protected List<Double> rankScores(Map<I, Double> userItems) {
         List<Double> sortedScores = new ArrayList<Double>();
         if (userItems == null) {
             return sortedScores;
         }
-        for (Map.Entry<Long, Double> e : userItems.entrySet()) {
+        for (Map.Entry<I, Double> e : userItems.entrySet()) {
             double pref = e.getValue();
             if (Double.isNaN(pref)) {
                 // we ignore any preference assigned as NaN

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/EvaluationMetricRunner.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/EvaluationMetricRunner.java
@@ -1,8 +1,5 @@
 package net.recommenders.rival.evaluation.metric;
 
-import java.io.*;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Properties;
 import net.recommenders.rival.core.DataModel;
 import net.recommenders.rival.core.SimpleParser;
 import net.recommenders.rival.evaluation.metric.error.AbstractErrorMetric;
@@ -10,6 +7,10 @@ import net.recommenders.rival.evaluation.metric.ranking.AbstractRankingMetric;
 import net.recommenders.rival.evaluation.metric.ranking.NDCG;
 import net.recommenders.rival.evaluation.parser.TrecEvalParser;
 import net.recommenders.rival.evaluation.strategy.EvaluationStrategy;
+
+import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
 
 /**
  * Runner for a single evaluation metric.
@@ -146,7 +147,7 @@ public class EvaluationMetricRunner {
      * @param append Whether or not to append results in an existing file.
      * @throws FileNotFoundException If file not found.
      */
-    public static void generateOutput(final DataModel<Long, Long> testModel, final int[] rankingCutoffs, EvaluationMetric<Long> metric, String metricName, Boolean perUser, File resultsFile, Boolean overwrite, Boolean append) throws FileNotFoundException {
+    public static <U, I> void generateOutput(final DataModel<U, I> testModel, final int[] rankingCutoffs, EvaluationMetric<U> metric, String metricName, Boolean perUser, File resultsFile, Boolean overwrite, Boolean append) throws FileNotFoundException {
         PrintStream out = null;
         if (overwrite && append) {
             System.out.println("Incompatible arguments: overwrite && append!!!");
@@ -161,13 +162,13 @@ public class EvaluationMetricRunner {
         metric.compute();
         out.println(metricName + "\tall\t" + metric.getValue());
         for (int c : rankingCutoffs) {
-            out.println(metricName + "@" + c + "\tall\t" + ((AbstractRankingMetric) metric).getValueAt(c));
+            out.println(metricName + "@" + c + "\tall\t" + ((AbstractRankingMetric<U, I>) metric).getValueAt(c));
         }
         if (perUser) {
-            for (Long user : testModel.getUsers()) {
+            for (U user : testModel.getUsers()) {
                 out.println(metricName + "\t" + user + "\t" + metric.getValue(user));
                 for (int c : rankingCutoffs) {
-                    out.println(metricName + "@" + c + "\t" + user + "\t" + ((AbstractRankingMetric) metric).getValueAt(user, c));
+                    out.println(metricName + "@" + c + "\t" + user + "\t" + ((AbstractRankingMetric<U, I>) metric).getValueAt(user, c));
                 }
             }
         }

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/AbstractErrorMetric.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/AbstractErrorMetric.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * @param <U> - type associated to users' ids
+ * @param <I> - type associated to items' ids
+ *
  * @author <a href="http://github.com/alansaid">Alan</a>
  * @author <a href="http://github.com/abellogin">Alejandro</a>
  */

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/AbstractErrorMetric.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/AbstractErrorMetric.java
@@ -1,18 +1,19 @@
 package net.recommenders.rival.evaluation.metric.error;
 
+import net.recommenders.rival.core.DataModel;
+import net.recommenders.rival.evaluation.metric.AbstractMetric;
+import net.recommenders.rival.evaluation.metric.EvaluationMetric;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import net.recommenders.rival.evaluation.metric.*;
-import net.recommenders.rival.core.DataModel;
-
 import java.util.Map;
 
 /**
  * @author <a href="http://github.com/alansaid">Alan</a>
  * @author <a href="http://github.com/abellogin">Alejandro</a>
  */
-public abstract class AbstractErrorMetric extends AbstractMetric implements EvaluationMetric<Long> {
+public abstract class AbstractErrorMetric<U, I> extends AbstractMetric<U, I> implements EvaluationMetric<U> {
 
     /**
      * Type of error strategy: what to do when there is no predicted rating but
@@ -50,7 +51,7 @@ public abstract class AbstractErrorMetric extends AbstractMetric implements Eval
      * @param predictions predicted scores for users and items
      * @param test groundtruth information for users and items
      */
-    public AbstractErrorMetric(DataModel<Long, Long> predictions, DataModel<Long, Long> test) {
+    public AbstractErrorMetric(DataModel<U, I> predictions, DataModel<U, I> test) {
         this(predictions, test, ErrorStrategy.NOT_CONSIDER_NAN);
     }
 
@@ -61,7 +62,7 @@ public abstract class AbstractErrorMetric extends AbstractMetric implements Eval
      * @param test groundtruth information for users and items
      * @param strategy the error strategy
      */
-    public AbstractErrorMetric(DataModel<Long, Long> predictions, DataModel<Long, Long> test, ErrorStrategy strategy) {
+    public AbstractErrorMetric(DataModel<U, I> predictions, DataModel<U, I> test, ErrorStrategy strategy) {
         super(predictions, test);
 
         this.value = Double.NaN;
@@ -74,22 +75,22 @@ public abstract class AbstractErrorMetric extends AbstractMetric implements Eval
      *
      * @return a map with the transformed data, one list per user
      */
-    public Map<Long, List<Double>> processDataAsPredictedDifferencesToTest() {
-        Map<Long, List<Double>> data = new HashMap<Long, List<Double>>();
-        Map<Long, Map<Long, Double>> actualRatings = test.getUserItemPreferences();
-        Map<Long, Map<Long, Double>> predictedRatings = predictions.getUserItemPreferences();
+    public Map<U, List<Double>> processDataAsPredictedDifferencesToTest() {
+        Map<U, List<Double>> data = new HashMap<U, List<Double>>();
+        Map<U, Map<I, Double>> actualRatings = test.getUserItemPreferences();
+        Map<U, Map<I, Double>> predictedRatings = predictions.getUserItemPreferences();
 
         emptyItems = 0;
         emptyUsers = 0;
 
-        for (long testUser : test.getUsers()) {
-            Map<Long, Double> ratings = actualRatings.get(testUser);
+        for (U testUser : test.getUsers()) {
+            Map<I, Double> ratings = actualRatings.get(testUser);
             List<Double> userData = data.get(testUser);
             if (userData == null) {
                 userData = new ArrayList<Double>();
                 data.put(testUser, userData);
             }
-            for (long testItem : ratings.keySet()) {
+            for (I testItem : ratings.keySet()) {
                 double realRating = ratings.get(testItem);
                 double predictedRating = Double.NaN; // NaN as default value
                 if (predictedRatings.containsKey(testUser)) {

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/MAE.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/MAE.java
@@ -1,9 +1,10 @@
 package net.recommenders.rival.evaluation.metric.error;
 
-import java.util.List;
-import java.util.Map;
 import net.recommenders.rival.core.DataModel;
 import net.recommenders.rival.evaluation.metric.EvaluationMetric;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * <a href="http://recsyswiki.com/wiki/RMSE" target="_blank">Mean absolute
@@ -11,7 +12,7 @@ import net.recommenders.rival.evaluation.metric.EvaluationMetric;
  *
  * @author <a href="http://github.com/abellogin">Alejandro</a>.
  */
-public class MAE extends AbstractErrorMetric implements EvaluationMetric<Long> {
+public class MAE<U, I> extends AbstractErrorMetric<U, I> implements EvaluationMetric<U> {
 
     /**
      * Default constructor with predictions and groundtruth information
@@ -19,7 +20,7 @@ public class MAE extends AbstractErrorMetric implements EvaluationMetric<Long> {
      * @param predictions predicted scores for users and items
      * @param test groundtruth information for users and items
      */
-    public MAE(DataModel<Long, Long> predictions, DataModel<Long, Long> test) {
+    public MAE(DataModel<U, I> predictions, DataModel<U, I> test) {
         super(predictions, test);
     }
 
@@ -30,7 +31,7 @@ public class MAE extends AbstractErrorMetric implements EvaluationMetric<Long> {
      * @param test groundtruth information for users and items
      * @param errorStrategy the error strategy
      */
-    public MAE(DataModel<Long, Long> predictions, DataModel<Long, Long> test, ErrorStrategy errorStrategy) {
+    public MAE(DataModel<U, I> predictions, DataModel<U, I> test, ErrorStrategy errorStrategy) {
         super(predictions, test, errorStrategy);
     }
 
@@ -45,10 +46,10 @@ public class MAE extends AbstractErrorMetric implements EvaluationMetric<Long> {
             // since the data cannot change, avoid re-doing the calculations
             return;
         }
-        Map<Long, List<Double>> data = processDataAsPredictedDifferencesToTest();
+        Map<U, List<Double>> data = processDataAsPredictedDifferencesToTest();
         value = 0.0;
         int testItems = 0;
-        for (long testUser : test.getUsers()) {
+        for (U testUser : test.getUsers()) {
             int userItems = 0;
             double ume = 0.0;
 

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/RMSE.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/error/RMSE.java
@@ -1,10 +1,10 @@
 package net.recommenders.rival.evaluation.metric.error;
 
-import java.util.List;
 import net.recommenders.rival.core.DataModel;
-
-import java.util.Map;
 import net.recommenders.rival.evaluation.metric.EvaluationMetric;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * <a href="http://recsyswiki.com/wiki/RMSE" target="_blank">Root mean square
@@ -12,7 +12,7 @@ import net.recommenders.rival.evaluation.metric.EvaluationMetric;
  *
  * @author <a href="http://github.com/alansaid">Alan</a>.
  */
-public class RMSE extends AbstractErrorMetric implements EvaluationMetric<Long> {
+public class RMSE<U, I> extends AbstractErrorMetric<U, I> implements EvaluationMetric<U> {
 
     /**
      * Default constructor with predictions and groundtruth information
@@ -20,7 +20,7 @@ public class RMSE extends AbstractErrorMetric implements EvaluationMetric<Long> 
      * @param predictions predicted scores for users and items
      * @param test groundtruth information for users and items
      */
-    public RMSE(DataModel<Long, Long> predictions, DataModel<Long, Long> test) {
+    public RMSE(DataModel<U, I> predictions, DataModel<U, I> test) {
         super(predictions, test);
     }
 
@@ -31,7 +31,7 @@ public class RMSE extends AbstractErrorMetric implements EvaluationMetric<Long> 
      * @param test groundtruth information for users and items
      * @param errorStrategy the error strategy
      */
-    public RMSE(DataModel<Long, Long> predictions, DataModel<Long, Long> test, ErrorStrategy errorStrategy) {
+    public RMSE(DataModel<U, I> predictions, DataModel<U, I> test, ErrorStrategy errorStrategy) {
         super(predictions, test, errorStrategy);
     }
 
@@ -46,10 +46,10 @@ public class RMSE extends AbstractErrorMetric implements EvaluationMetric<Long> 
             // since the data cannot change, avoid re-doing the calculations
             return;
         }
-        Map<Long, List<Double>> data = processDataAsPredictedDifferencesToTest();
+        Map<U, List<Double>> data = processDataAsPredictedDifferencesToTest();
         value = 0.0;
         int testItems = 0;
-        for (long testUser : test.getUsers()) {
+        for (U testUser : test.getUsers()) {
             int userItems = 0;
             double umse = 0.0;
 

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/ranking/AbstractRankingMetric.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/ranking/AbstractRankingMetric.java
@@ -1,9 +1,13 @@
 package net.recommenders.rival.evaluation.metric.ranking;
 
-import java.util.*;
 import net.recommenders.rival.core.DataModel;
 import net.recommenders.rival.evaluation.metric.AbstractMetric;
 import net.recommenders.rival.evaluation.metric.EvaluationMetric;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Normalized <a href="http://recsyswiki.com/wiki/Discounted_Cumulative_Gain"
@@ -13,7 +17,7 @@ import net.recommenders.rival.evaluation.metric.EvaluationMetric;
  * @author <a href="http://github.com/alansaid">Alan</a>.
  * @author <a href="http://github.com/abellogin">Alejandro</a>.
  */
-public abstract class AbstractRankingMetric extends AbstractMetric implements EvaluationMetric<Long> {
+public abstract class AbstractRankingMetric<U, I> extends AbstractMetric<U, I> implements EvaluationMetric<U> {
 
     /**
      * Global metric value
@@ -34,7 +38,7 @@ public abstract class AbstractRankingMetric extends AbstractMetric implements Ev
      * @param predictions predicted scores for users and items
      * @param test groundtruth information for users and items
      */
-    public AbstractRankingMetric(DataModel<Long, Long> predictions, DataModel<Long, Long> test) {
+    public AbstractRankingMetric(DataModel<U, I> predictions, DataModel<U, I> test) {
         this(predictions, test, 1.0);
     }
 
@@ -45,7 +49,7 @@ public abstract class AbstractRankingMetric extends AbstractMetric implements Ev
      * @param test groundtruth ratings
      * @param relThreshold relevance threshold
      */
-    public AbstractRankingMetric(DataModel<Long, Long> predictions, DataModel<Long, Long> test, double relThreshold) {
+    public AbstractRankingMetric(DataModel<U, I> predictions, DataModel<U, I> test, double relThreshold) {
         this(predictions, test, relThreshold, new int[]{});
     }
 
@@ -57,7 +61,7 @@ public abstract class AbstractRankingMetric extends AbstractMetric implements Ev
      * @param ats cutoffs
      * @param relThreshold relevance threshold
      */
-    public AbstractRankingMetric(DataModel<Long, Long> predictions, DataModel<Long, Long> test, double relThreshold, int[] ats) {
+    public AbstractRankingMetric(DataModel<U, I> predictions, DataModel<U, I> test, double relThreshold, int[] ats) {
         super(predictions, test);
         this.value = Double.NaN;
         this.ats = ats;
@@ -70,16 +74,16 @@ public abstract class AbstractRankingMetric extends AbstractMetric implements Ev
      *
      * @return a map with the transformed data, one list per user
      */
-    public Map<Long, List<Double>> processDataAsRankedTestRelevance() {
-        Map<Long, List<Double>> data = new HashMap<Long, List<Double>>();
+    public Map<U, List<Double>> processDataAsRankedTestRelevance() {
+        Map<U, List<Double>> data = new HashMap<U, List<Double>>();
 
-        Map<Long, Map<Long, Double>> predictedRatings = predictions.getUserItemPreferences();
-        for (long testUser : test.getUsers()) {
-            Map<Long, Double> userPredictedRatings = predictedRatings.get(testUser);
-            Map<Long, Double> userRelevance = test.getUserItemPreferences().get(testUser);
+        Map<U, Map<I, Double>> predictedRatings = predictions.getUserItemPreferences();
+        for (U testUser : test.getUsers()) {
+            Map<I, Double> userPredictedRatings = predictedRatings.get(testUser);
+            Map<I, Double> userRelevance = test.getUserItemPreferences().get(testUser);
             if (userPredictedRatings != null) {
                 List<Double> rankedTestRel = new ArrayList<Double>();
-                for (long item : rankItems(userPredictedRatings)) {
+                for (I item : rankItems(userPredictedRatings)) {
                     double rel = 0.0;
                     if (userRelevance.containsKey(item)) {
                         rel = userRelevance.get(item);
@@ -99,10 +103,10 @@ public abstract class AbstractRankingMetric extends AbstractMetric implements Ev
      * @param user a user
      * @return the number of relevant items the user has in the test set
      */
-    protected double getNumberOfRelevantItems(long user) {
+    protected double getNumberOfRelevantItems(U user) {
         int n = 0;
         if (test.getUserItemPreferences().containsKey(user)) {
-            for (Map.Entry<Long, Double> e : test.getUserItemPreferences().get(user).entrySet()) {
+            for (Map.Entry<I, Double> e : test.getUserItemPreferences().get(user).entrySet()) {
                 if (e.getValue() >= relevanceThreshold) {
                     n++;
                 }
@@ -151,5 +155,5 @@ public abstract class AbstractRankingMetric extends AbstractMetric implements Ev
      * @return the metric corresponding to the requested user at the cutoff
      * level
      */
-    public abstract double getValueAt(long user, int at);
+    public abstract double getValueAt(U user, int at);
 }

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/ranking/AbstractRankingMetric.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/ranking/AbstractRankingMetric.java
@@ -10,9 +10,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Normalized <a href="http://recsyswiki.com/wiki/Discounted_Cumulative_Gain"
- * target="_blank">discounted cumulative gain</a> (NDCG) of a ranked list of
- * items.
+ * Abstract class which represents all the basic elements of a
+ * ranking based metric.
+ *
+ * @param <U> - type associated to users' ids
+ * @param <I> - type associated to items' ids
  *
  * @author <a href="http://github.com/alansaid">Alan</a>.
  * @author <a href="http://github.com/abellogin">Alejandro</a>.

--- a/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/ranking/MAP.java
+++ b/rival-evaluate/src/main/java/net/recommenders/rival/evaluation/metric/ranking/MAP.java
@@ -1,22 +1,23 @@
 package net.recommenders.rival.evaluation.metric.ranking;
 
+import net.recommenders.rival.core.DataModel;
+import net.recommenders.rival.evaluation.metric.EvaluationMetric;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.recommenders.rival.core.DataModel;
-import net.recommenders.rival.evaluation.metric.EvaluationMetric;
 
 /**
  * Mean Average Precision of a ranked list of items.
  *
  * @author <a href="http://github.com/abellogin">Alejandro</a>.
  */
-public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long> {
+public class MAP<U, I> extends AbstractRankingMetric<U, I> implements EvaluationMetric<U> {
 
     /**
      * AP (average precision) values per user at each cutoff level
      */
-    private Map<Integer, Map<Long, Double>> userMAPAtCutoff;
+    private Map<Integer, Map<U, Double>> userMAPAtCutoff;
 
     /**
      * Default constructor with predictions and groundtruth information
@@ -24,7 +25,7 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
      * @param predictions predicted scores for users and items
      * @param test groundtruth information for users and items
      */
-    public MAP(DataModel<Long, Long> predictions, DataModel<Long, Long> test) {
+    public MAP(DataModel<U, I> predictions, DataModel<U, I> test) {
         this(predictions, test, 1.0);
     }
 
@@ -35,7 +36,7 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
      * @param test groundtruth ratings
      * @param relThreshold relevance threshold
      */
-    public MAP(DataModel<Long, Long> predictions, DataModel<Long, Long> test, double relThreshold) {
+    public MAP(DataModel<U, I> predictions, DataModel<U, I> test, double relThreshold) {
         this(predictions, test, relThreshold, new int[]{});
     }
 
@@ -47,7 +48,7 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
      * @param relThreshold the relevance threshold
      * @param ats cutoffs
      */
-    public MAP(DataModel<Long, Long> predictions, DataModel<Long, Long> test, double relThreshold, int[] ats) {
+    public MAP(DataModel<U, I> predictions, DataModel<U, I> test, double relThreshold, int[] ats) {
         super(predictions, test, relThreshold, ats);
     }
 
@@ -62,12 +63,12 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
             return;
         }
         value = 0.0;
-        Map<Long, List<Double>> data = processDataAsRankedTestRelevance();
-        userMAPAtCutoff = new HashMap<Integer, Map<Long, Double>>();
-        metricPerUser = new HashMap<Long, Double>();
+        Map<U, List<Double>> data = processDataAsRankedTestRelevance();
+        userMAPAtCutoff = new HashMap<Integer, Map<U, Double>>();
+        metricPerUser = new HashMap<U, Double>();
 
         int nUsers = 0;
-        for (long user : data.keySet()) {
+        for (U user : data.keySet()) {
             List<Double> sortedList = data.get(user);
             // number of relevant items for this user
             double uRel = getNumberOfRelevantItems(user);
@@ -84,9 +85,9 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
                 // compute at a particular cutoff
                 for (int at : ats) {
                     if (rank == at) {
-                        Map<Long, Double> m = userMAPAtCutoff.get(at);
+                        Map<U, Double> m = userMAPAtCutoff.get(at);
                         if (m == null) {
-                            m = new HashMap<Long, Double>();
+                            m = new HashMap<U, Double>();
                             userMAPAtCutoff.put(at, m);
                         }
                         m.put(user, uMAP / uRel);
@@ -98,9 +99,9 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
             // assign the MAP of the whole list to those cutoffs larger than the list's size
             for (int at : ats) {
                 if (rank <= at) {
-                    Map<Long, Double> m = userMAPAtCutoff.get(at);
+                    Map<U, Double> m = userMAPAtCutoff.get(at);
                     if (m == null) {
-                        m = new HashMap<Long, Double>();
+                        m = new HashMap<U, Double>();
                         userMAPAtCutoff.put(at, m);
                     }
                     m.put(user, uMAP);
@@ -126,7 +127,7 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
         if (userMAPAtCutoff.containsKey(at)) {
             int n = 0;
             double map = 0.0;
-            for (long u : userMAPAtCutoff.get(at).keySet()) {
+            for (U u : userMAPAtCutoff.get(at).keySet()) {
                 double uMAP = getValueAt(u, at);
                 if (!Double.isNaN(uMAP)) {
                     map += uMAP;
@@ -149,7 +150,7 @@ public class MAP extends AbstractRankingMetric implements EvaluationMetric<Long>
      * the cutoff level
      */
     @Override
-    public double getValueAt(long user, int at) {
+    public double getValueAt(U user, int at) {
         if (userMAPAtCutoff.containsKey(at) && userMAPAtCutoff.get(at).containsKey(user)) {
             double map = userMAPAtCutoff.get(at).get(user);
             return map;

--- a/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/MAPTest.java
+++ b/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/MAPTest.java
@@ -1,14 +1,14 @@
 package net.recommenders.rival.evaluation.metric;
 
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
-
 import net.recommenders.rival.core.DataModel;
+import net.recommenders.rival.evaluation.metric.ranking.MAP;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.Map;
-import net.recommenders.rival.evaluation.metric.ranking.MAP;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="http://github.com/alansaid">Alan</a>.
@@ -28,7 +28,7 @@ public class MAPTest {
                 predictions.addPreference(i, j, i * j % 5 + 1.0);
             }
         }
-        MAP map = new MAP(predictions, test, 1.0, new int[]{1, 5, 10, 20});
+        MAP<Long, Long> map = new MAP<Long, Long>(predictions, test, 1.0, new int[]{1, 5, 10, 20});
 
         map.compute();
 
@@ -59,7 +59,7 @@ public class MAPTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        MAP map = new MAP(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
+        MAP<Long, Long> map = new MAP<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
 
         map.compute();
 
@@ -92,7 +92,7 @@ public class MAPTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        MAP map = new MAP(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
+        MAP<Long, Long> map = new MAP<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
 
         map.compute();
 

--- a/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/NDCGTest.java
+++ b/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/NDCGTest.java
@@ -1,16 +1,14 @@
 package net.recommenders.rival.evaluation.metric;
 
-import java.util.HashSet;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
-
 import net.recommenders.rival.core.DataModel;
 import net.recommenders.rival.evaluation.metric.ranking.NDCG;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.Map;
-import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="http://github.com/alansaid">Alan</a>.
@@ -28,7 +26,7 @@ public class NDCGTest {
                 predictions.addPreference(i, j, i * j % 5 + 1.0);
             }
         }
-        NDCG ndcg = new NDCG(predictions, test, new int[]{5, 10, 20});
+        NDCG<Long, Long> ndcg = new NDCG<Long, Long>(predictions, test, new int[]{5, 10, 20});
 
         ndcg.compute();
 
@@ -59,7 +57,7 @@ public class NDCGTest {
         predictions.addPreference(1L, 4L, 1.0);
         predictions.addPreference(1L, 1L, 0.0);
 
-        NDCG ndcg = new NDCG(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
+        NDCG<Long, Long> ndcg = new NDCG<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
 
         ndcg.compute();
 
@@ -79,7 +77,7 @@ public class NDCGTest {
         predictions.addPreference(1L, 2L, 1.0);
         predictions.addPreference(1L, 1L, 0.0);
 
-        ndcg = new NDCG(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
+        ndcg = new NDCG<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
 
         ndcg.compute();
 
@@ -97,7 +95,7 @@ public class NDCGTest {
         predictions.addPreference(1L, 3L, 1.0);
         predictions.addPreference(1L, 1L, 0.0);
 
-        ndcg = new NDCG(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
+        ndcg = new NDCG<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
 
         ndcg.compute();
 
@@ -118,7 +116,7 @@ public class NDCGTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        NDCG ndcg = new NDCG(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
+        NDCG<Long, Long> ndcg = new NDCG<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
 
         ndcg.compute();
 
@@ -151,7 +149,7 @@ public class NDCGTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        NDCG ndcg = new NDCG(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
+        NDCG<Long, Long> ndcg = new NDCG<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5}, NDCG.TYPE.TREC_EVAL);
 
         ndcg.compute();
 

--- a/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/PrecisionTest.java
+++ b/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/PrecisionTest.java
@@ -1,14 +1,14 @@
 package net.recommenders.rival.evaluation.metric;
 
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
-
 import net.recommenders.rival.core.DataModel;
+import net.recommenders.rival.evaluation.metric.ranking.Precision;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.Map;
-import net.recommenders.rival.evaluation.metric.ranking.Precision;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="http://github.com/alansaid">Alan</a>.
@@ -26,7 +26,7 @@ public class PrecisionTest {
                 predictions.addPreference(i, j, i * j % 5 + 1.0);
             }
         }
-        Precision  precision = new Precision(predictions, test, 1.0, new int[]{5, 10, 20});
+        Precision<Long, Long> precision = new Precision<Long, Long>(predictions, test, 1.0, new int[]{5, 10, 20});
 
         precision.compute();
 
@@ -37,6 +37,32 @@ public class PrecisionTest {
         Map<Long, Double> precisionPerUser = precision.getValuePerUser();
         for (Map.Entry<Long, Double> e : precisionPerUser.entrySet()) {
             long user = e.getKey();
+            double value = e.getValue();
+            assertEquals(1.0, value, 0.0);
+        }
+    }
+
+    @Test
+    public void testSameGroundtruthAsPredictionsStringIDs() {
+        DataModel<String, String> predictions = new DataModel<String, String>();
+        DataModel<String, String> test = new DataModel<String, String>();
+        for (long i = 1L; i < 20; i++) {
+            for (long j = 1L; j < 15; j++) {
+                test.addPreference(String.valueOf("u" + i), String.valueOf("i" + j), i * j % 5 + 1.0);
+                predictions.addPreference(String.valueOf("u" + i), String.valueOf("i" + j), i * j % 5 + 1.0);
+            }
+        }
+        Precision<String, String> precision = new Precision<String, String>(predictions, test, 1.0, new int[]{5, 10, 20});
+
+        precision.compute();
+
+        assertEquals(1.0, precision.getValue(), 0.0);
+        assertEquals(1.0, precision.getValueAt(5), 0.0);
+        assertEquals(1.0, precision.getValueAt(10), 0.0);
+
+        Map<String, Double> precisionPerUser = precision.getValuePerUser();
+        for (Map.Entry<String, Double> e : precisionPerUser.entrySet()) {
+            String user = e.getKey();
             double value = e.getValue();
             assertEquals(1.0, value, 0.0);
         }
@@ -56,7 +82,7 @@ public class PrecisionTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        Precision precision = new Precision(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
+        Precision<Long, Long> precision = new Precision<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
 
         precision.compute();
 
@@ -89,7 +115,7 @@ public class PrecisionTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        Precision precision = new Precision(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
+        Precision<Long, Long> precision = new Precision<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
 
         precision.compute();
 

--- a/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/RMSETest.java
+++ b/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/RMSETest.java
@@ -1,14 +1,14 @@
 package net.recommenders.rival.evaluation.metric;
 
-import net.recommenders.rival.evaluation.metric.error.RMSE;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
-
 import net.recommenders.rival.core.DataModel;
+import net.recommenders.rival.evaluation.metric.error.RMSE;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="http://github.com/alansaid">Alan</a>.
@@ -26,7 +26,7 @@ public class RMSETest<U, I> {
                 predictions.addPreference((long) i, (long) j, (double) i * j);
             }
         }
-        RMSE rmse = new RMSE(predictions, test);
+        RMSE<Long, Long> rmse = new RMSE<Long, Long>(predictions, test);
 
         rmse.compute();
 

--- a/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/RecallTest.java
+++ b/rival-evaluate/src/test/java/net/recommenders/rival/evaluation/metric/RecallTest.java
@@ -1,14 +1,14 @@
 package net.recommenders.rival.evaluation.metric;
 
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
-
 import net.recommenders.rival.core.DataModel;
+import net.recommenders.rival.evaluation.metric.ranking.Recall;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.Map;
-import net.recommenders.rival.evaluation.metric.ranking.Recall;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="http://github.com/alansaid">Alan</a>.
@@ -28,7 +28,7 @@ public class RecallTest {
                 predictions.addPreference(i, j, i * j % 5 + 1.0);
             }
         }
-        Recall recall = new Recall(predictions, test, 1.0, new int[]{5, 10, 20});
+        Recall<Long, Long> recall = new Recall<Long, Long>(predictions, test, 1.0, new int[]{5, 10, 20});
 
         recall.compute();
 
@@ -58,7 +58,7 @@ public class RecallTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        Recall recall = new Recall(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
+        Recall<Long, Long> recall = new Recall<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
 
         recall.compute();
 
@@ -91,7 +91,7 @@ public class RecallTest {
         predictions.addPreference(1L, 3L, 5.0);
         predictions.addPreference(1L, 4L, 1.0);
 
-        Recall recall = new Recall(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
+        Recall<Long, Long> recall = new Recall<Long, Long>(predictions, test, 1.0, new int[]{1, 2, 3, 4, 5});
 
         recall.compute();
 


### PR DESCRIPTION
The **DataModel** definition grants to use a generic type of identifiers for users and items. This capability is not used in the previous version, in which, a specific type was used (**Long**).

The aim of this PR is to generify the evaluation metrics that uses the **DataModel** for predictions and test ratings, in order to be able to work with generic type of identifier according to the user needs.

A single test case has been added that simply shows how to use the metrics with generic parameters.
Furthermore has been inserted some javadoc tag in order to document the generics type parameters for **AbstractMetric**, **AbstractRankingMetric** and **AbstractErrorMetric**.  