### PR TITLE
Set correct path to ML data file

### DIFF
--- a/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/CrossValidatedMahoutKNNRecommenderEvaluator.java
+++ b/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/CrossValidatedMahoutKNNRecommenderEvaluator.java
@@ -86,8 +86,9 @@ public final class CrossValidatedMahoutKNNRecommenderEvaluator {
         String folder = "data/ml-100k";
         String modelPath = "data/ml-100k/model/";
         String recPath = "data/ml-100k/recommendations/";
+        String dataFile = "data/ml-100k/ml-100k/u.data";
         int nFolds = N_FOLDS;
-        prepareSplits(url, nFolds, "data/ml-100k/u.data", folder, modelPath);
+        prepareSplits(url, nFolds, "dataFile, folder, modelPath);
         recommend(nFolds, modelPath, recPath);
         // the strategy files are (currently) being ignored
         prepareStrategy(nFolds, modelPath, recPath, modelPath);

--- a/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/CrossValidatedMahoutKNNRecommenderEvaluator.java
+++ b/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/CrossValidatedMahoutKNNRecommenderEvaluator.java
@@ -88,7 +88,7 @@ public final class CrossValidatedMahoutKNNRecommenderEvaluator {
         String recPath = "data/ml-100k/recommendations/";
         String dataFile = "data/ml-100k/ml-100k/u.data";
         int nFolds = N_FOLDS;
-        prepareSplits(url, nFolds, "dataFile, folder, modelPath);
+        prepareSplits(url, nFolds, dataFile, folder, modelPath);
         recommend(nFolds, modelPath, recPath);
         // the strategy files are (currently) being ignored
         prepareStrategy(nFolds, modelPath, recPath, modelPath);

--- a/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/RandomSplitMahoutKNNRecommenderEvaluator.java
+++ b/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/RandomSplitMahoutKNNRecommenderEvaluator.java
@@ -86,8 +86,9 @@ public final class RandomSplitMahoutKNNRecommenderEvaluator {
         String folder = "data/ml-100k";
         String modelPath = "data/ml-100k/model/";
         String recPath = "data/ml-100k/recommendations/";
+        String dataFile = "data/ml-100k/ml-100k/u.data";
         float percentage = PERCENTAGE;
-        prepareSplits(url, percentage, "data/ml-100k/u.data", folder, modelPath);
+        prepareSplits(url, percentage, dataFile, folder, modelPath);
         recommend(modelPath, recPath);
         // the strategy files are (currently) being ignored
         prepareStrategy(modelPath, recPath, modelPath);

--- a/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/TemporalSplitMahoutKNNRecommenderEvaluator.java
+++ b/rival-examples/src/main/java/net/recommenders/rival/examples/movielens100k/TemporalSplitMahoutKNNRecommenderEvaluator.java
@@ -82,8 +82,9 @@ public final class TemporalSplitMahoutKNNRecommenderEvaluator {
         String folder = "data/ml-100k";
         String modelPath = "data/ml-100k/model/";
         String recPath = "data/ml-100k/recommendations/";
+        String dataFile = "data/ml-100k/ml-100k/u.data";
         float percentage = PERCENTAGE;
-        prepareSplits(url, percentage, "data/ml-100k/u.data", folder, modelPath);
+        prepareSplits(url, percentage, dataFile, folder, modelPath);
         recommend(modelPath, recPath);
         // the strategy files are (currently) being ignored
         prepareStrategy(modelPath, recPath, modelPath);


### PR DESCRIPTION
The code in the `net.recommenders.rival.examples.movielens100k` examples downloads the `ml-100k.zip` file into the `data/ml-100k` directory, and then unzips it, resulting in the data being in `data/ml-100k/ml-100k`.

However, in the call to the `prepareSplits()` method the path to the input file is specified as `data/ml-100k/u.data`, which results in a NullPointerException when it tries to read from this non-existent file.

This minimal change is to specify the correct path to the input file in these source files.

I was running this on OS X, so I don't know whether the behavior of the unzipping code is perhaps different on that platform vs. others.